### PR TITLE
AOT compile canopy development functions

### DIFF
--- a/aquacrop/solution.py
+++ b/aquacrop/solution.py
@@ -15,10 +15,7 @@ __all__ = [
     "capillary_rise",
     "germination",
     "growth_stage",
-    "cc_development",
-    "cc_required_time",
     "adjust_CCx",
-    "update_CCx_CDC",
     "canopy_cover",
     "soil_evaporation",
     "aeration_stress",
@@ -2009,6 +2006,7 @@ def water_stress(
 
 # Cell
 # @njit()
+@cc.export("_cc_development", "f8(f8,f8,f8,f8,f8,unicode_type,f8)")
 def cc_development(CCo, CCx, CGC, CDC, dt, Mode, CCx0):
     """
     Function to calculate canopy cover development by end of the current simulation day
@@ -2080,6 +2078,7 @@ def cc_development(CCo, CCx, CGC, CDC, dt, Mode, CCx0):
 
 # Cell
 # @njit()
+@cc.export("_cc_required_time", "f8(f8,f8,f8,f8,f8,unicode_type)")
 def cc_required_time(CCprev, CCo, CCx, CGC, CDC, Mode):
     """
     Function to find time required to reach CC at end of previous day, given current CGC or CDC
@@ -2174,12 +2173,12 @@ def adjust_CCx(CCprev, CCo, CCx, CGC, CDC, dt, tSum, Crop_CanopyDevEnd, Crop_CCx
     """
 
     ## Get time required to reach CC on previous day ##
-    tCCtmp = cc_required_time(CCprev, CCo, CCx, CGC, CDC, "CGC")
+    tCCtmp = _cc_required_time(CCprev, CCo, CCx, CGC, CDC, "CGC")
 
     ## Determine CCx adjusted ##
     if tCCtmp > 0:
         tCCtmp = tCCtmp + (Crop_CanopyDevEnd - tSum) + dt
-        CCxAdj = cc_development(CCo, CCx, CGC, CDC, tCCtmp, "Growth", Crop_CCx)
+        CCxAdj = _cc_development(CCo, CCx, CGC, CDC, tCCtmp, "Growth", Crop_CCx)
     else:
         CCxAdj = 0
 
@@ -2188,6 +2187,7 @@ def adjust_CCx(CCprev, CCo, CCx, CGC, CDC, dt, tSum, Crop_CanopyDevEnd, Crop_CCx
 
 # Cell
 # @njit()
+@cc.export("_update_CCx_CDC", "(f8,f8,f8,f8)")
 def update_CCx_CDC(CCprev, CDC, CCx, dt):
     """
     Function to update CCx and CDC parameter valyes for rewatering in late season of an early declining canopy
@@ -2350,7 +2350,7 @@ def canopy_cover(Crop, prof, Soil_zTop, InitCond, GDD, Et0, GrowingSeason):
             else:
                 # Canopy growing
                 tmp_tCC = tCCadj - Crop.Emergence
-                NewCond.CC_NS = cc_development(
+                NewCond.CC_NS = _cc_development(
                     Crop.CC0, 0.98 * Crop.CCx, Crop.CGC, Crop.CDC, tmp_tCC, "Growth", Crop.CCx
                 )
 
@@ -2368,7 +2368,7 @@ def canopy_cover(Crop, prof, Soil_zTop, InitCond, GDD, Et0, GrowingSeason):
             else:
                 # Late-season stage - canopy decline
                 tmp_tCC = tCCadj - Crop.Senescence
-                NewCond.CC_NS = cc_development(
+                NewCond.CC_NS = _cc_development(
                     Crop.CC0,
                     NewCond.CCxAct_NS,
                     Crop.CGC,
@@ -2393,7 +2393,7 @@ def canopy_cover(Crop, prof, Soil_zTop, InitCond, GDD, Et0, GrowingSeason):
                 # growth. In this case, assume no leaf water expansion stress
                 if InitCond_ProtectedSeed == True:
                     tmp_tCC = tCCadj - Crop.Emergence
-                    NewCond.CC = cc_development(
+                    NewCond.CC = _cc_development(
                         Crop.CC0, Crop.CCx, Crop.CGC, Crop.CDC, tmp_tCC, "Growth", Crop.CCx
                     )
                     # Check if seed protection should be turned off
@@ -2433,14 +2433,14 @@ def canopy_cover(Crop, prof, Soil_zTop, InitCond, GDD, Et0, GrowingSeason):
 
                             # Approaching maximum canopy cover size
                             tmp_tCC = tCCadj - Crop.Emergence
-                            NewCond.CC = cc_development(
+                            NewCond.CC = _cc_development(
                                 Crop.CC0, Crop.CCx, Crop.CGC, Crop.CDC, tmp_tCC, "Growth", Crop.CCx
                             )
                         else:
 
                             # Determine time required to reach CC on previous,
                             # day, given CGCAdj value
-                            tReq = cc_required_time(
+                            tReq = _cc_required_time(
                                 InitCond_CC, NewCond.CC0adj, CCXadj, CGCadj, Crop.CDC, "CGC"
                             )
                             if tReq > 0:
@@ -2448,7 +2448,7 @@ def canopy_cover(Crop, prof, Soil_zTop, InitCond, GDD, Et0, GrowingSeason):
                                 # Calclate GDD's for canopy growth
                                 tmp_tCC = tReq + dtCC
                                 # Determine new canopy size
-                                NewCond.CC = cc_development(
+                                NewCond.CC = _cc_development(
                                     NewCond.CC0adj,
                                     CCXadj,
                                     CGCadj,
@@ -2476,7 +2476,7 @@ def canopy_cover(Crop, prof, Soil_zTop, InitCond, GDD, Et0, GrowingSeason):
                 else:
                     # Canopy approaching maximum size
                     tmp_tCC = tCCadj - Crop.Emergence
-                    NewCond.CC = cc_development(
+                    NewCond.CC = _cc_development(
                         Crop.CC0, Crop.CCx, Crop.CGC, Crop.CDC, tmp_tCC, "Growth", Crop.CCx
                     )
                     NewCond.CC0adj = Crop.CC0
@@ -2503,7 +2503,7 @@ def canopy_cover(Crop, prof, Soil_zTop, InitCond, GDD, Et0, GrowingSeason):
                 CDCadj = Crop.CDC * ((NewCond.CCxAct + 2.29) / (Crop.CCx + 2.29))
                 # Determine new canopy size
                 tmp_tCC = tCCadj - Crop.Senescence
-                NewCond.CC = cc_development(
+                NewCond.CC = _cc_development(
                     NewCond.CC0adj,
                     NewCond.CCxAct,
                     Crop.CGC,
@@ -2620,11 +2620,11 @@ def canopy_cover(Crop, prof, Soil_zTop, InitCond, GDD, Et0, GrowingSeason):
                         # Rewatering of canopy in late season
                         # Get new values for CCx and CDC
                         tmp_tCC = tCCadj - dtCC - Crop.Senescence
-                        CCXadj, CDCadj = update_CCx_CDC(InitCond_CC, Crop.CDC, Crop.CCx, tmp_tCC)
+                        CCXadj, CDCadj = _update_CCx_CDC(InitCond_CC, Crop.CDC, Crop.CCx, tmp_tCC)
                         NewCond.CCxAct = CCXadj
                         # Get new CC value for end of current day
                         tmp_tCC = tCCadj - Crop.Senescence
-                        NewCond.CC = cc_development(
+                        NewCond.CC = _cc_development(
                             NewCond.CC0adj, CCXadj, Crop.CGC, CDCadj, tmp_tCC, "Decline", CCXadj
                         )
                         # Check for crop growth termination

--- a/aquacrop/solution.py
+++ b/aquacrop/solution.py
@@ -48,7 +48,13 @@ cc = CC("solution_aot")
 
 # This compiled function is called a few times inside other functions
 if __name__ != "__main__":
-    from .solution_aot import _root_zone_water, _water_stress, _evap_layer_water_content
+    from .solution_aot import (
+        _root_zone_water,
+        _water_stress,
+        _evap_layer_water_content,
+        _cc_development,
+        _cc_required_time
+    )
 else:
     from solution_aot import _evap_layer_water_content
 

--- a/aquacrop/solution.py
+++ b/aquacrop/solution.py
@@ -53,7 +53,8 @@ if __name__ != "__main__":
         _water_stress,
         _evap_layer_water_content,
         _cc_development,
-        _cc_required_time
+        _cc_required_time,
+        _update_CCx_CDC
     )
 else:
     from solution_aot import _evap_layer_water_content


### PR DESCRIPTION
Hi @rbavery, this is to contribute to your [original PR](https://github.com/aquacropos/aquacrop/pull/33) to upsteam.
These changes move `cc_development`, `cc_required_time` and `update_CCx_CDC` to AOT.